### PR TITLE
[local] Add Azure R570 GRID driver to GPU operator

### DIFF
--- a/download_azure_grid_driver.sh
+++ b/download_azure_grid_driver.sh
@@ -18,6 +18,9 @@ get_grid_azure_url() {
 
     # Azure GRID driver version mapping
     case "$version" in
+        570.195.03*)
+            echo "https://download.microsoft.com/download/0541e1a5-dff2-4b8c-a79c-96a7664b1d49/NVIDIA-Linux-x86_64-570.195.03-grid-azure.run"
+            ;;
         550.144.06*)
             echo "https://download.microsoft.com/download/c5319e92-672e-4067-8d85-ab66a7a64db3/NVIDIA-Linux-x86_64-550.144.06-grid-azure.run"
             ;;

--- a/precompiled.Dockerfile
+++ b/precompiled.Dockerfile
@@ -107,7 +107,7 @@ RUN . /versions.env && \
             linux-headers-${KERNEL_VERSION} \
             linux-modules-${KERNEL_VERSION} \
             dkms && \
-        /tmp/download_azure_grid_driver.sh "550.144.06"; \
+        /tmp/download_azure_grid_driver.sh "570.195.03"; \
     fi
 
 RUN mkdir -p /opt/nvidia-driver/bin


### PR DESCRIPTION
### Description

Enable R570 Azure GRID driver

### Testing

- [x]  On arbok.us3.staging.dog cluster to make sure that NV instances can work with the newer driver