### PR TITLE
[local] Use 535.161.08 GRID driver for A10 GPUs

### DIFF
--- a/precompiled.Dockerfile
+++ b/precompiled.Dockerfile
@@ -107,7 +107,7 @@ RUN . /versions.env && \
             linux-headers-${KERNEL_VERSION} \
             linux-modules-${KERNEL_VERSION} \
             dkms && \
-        /tmp/download_azure_grid_driver.sh "570.195.03"; \
+        /tmp/download_azure_grid_driver.sh "535.161.08"; \
     fi
 
 RUN mkdir -p /opt/nvidia-driver/bin


### PR DESCRIPTION
### Description

Version `570.195.03` of the GRID driver introduces significant performance regression. Switching gpu-operator to use `535.161.08` version (used today by AMI image).

### Testing

On arbok.us3.staging.dog:
- [x] Run basic `/cuda-samples/vectorAdd` test.
- [x] Deploy piioner service and run performance test to make sure node managed by gpu-operator has the same performance as node with custom AMI (not managed by gpu-operator)   


### Breadcrumbs
Jira: [NODES-487](https://datadoghq.atlassian.net/browse/NODES-487)
Incident: [#incident-51051](https://dd.enterprise.slack.com/archives/C0ALJ8ZQ682)



[NODES-487]: https://datadoghq.atlassian.net/browse/NODES-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ