### PR TITLE
[local] feat(ckmb): switch ckmb image to use 570 grid driver in Azure

### DIFF
--- a/.ckmb/build.sh
+++ b/.ckmb/build.sh
@@ -112,7 +112,7 @@ cd -
 cp ubuntu22.04/precompiled/grid-driver /ckmb/grid-driver
 if [ "${KERNEL_VERSION##*-}" = "azure" ]; then
     # TODO: Azure supports only several GRID driver versions. Temporary hardcode the version.
-    ./download_azure_grid_driver.sh "535.161.08";
+    ./download_azure_grid_driver.sh "570.195.03";
 fi
 
 


### PR DESCRIPTION
### Description

After the issue with grid license is fixed we can switch Nvidia GRID driver to 570 branch.

### Testing

Tested on `arbok.us3.staging.dog`

- [x]  Run piioner basic performance tests with the new driver.